### PR TITLE
Fix: Use OS' default locale for date parsing

### DIFF
--- a/zrep-expire
+++ b/zrep-expire
@@ -7,6 +7,9 @@ import sys
 import argparse
 import re
 from pprint import pprint,pformat
+#use the OS's locale in order to parse the dates correctly
+import locale
+locale.setlocale(locale.LC_TIME, "")
 
 # This program calls the 'zfs' utility to gather information. The output of the command is decoded
 # as UTF-8. If your system locale doesn't use UTF-8 encoding, change the 'get_all_filesystems'


### PR DESCRIPTION
On my ArchLinux (de_DE.utf8) on python3 (in python2 it worked) I need to call locale.setlocale(locale.LC_TIME, "") for the dates to get parsed correctly. Otherwise it will throw an exception.