### PR TITLE
Fix: only consider filesystems in get_all_filesystems

### DIFF
--- a/zrep-expire
+++ b/zrep-expire
@@ -77,7 +77,7 @@ def parse_rules(therules):
     return parsed_rules
 
 def get_all_filesystems():
-    cmd = [ '/sbin/zfs', 'list', '-H', '-o', 'name' ]
+    cmd = [ '/sbin/zfs', 'list', '-H', '-t', 'filesystem', '-o', 'name' ]
     try:
         filesystems = subprocess.check_output(cmd).decode('utf-8').split("\n")
         filesystems = sorted(filter(lambda x: len( x ) > 0, ( line.strip() for line in filesystems ) ))


### PR DESCRIPTION
On my machine, sometimes snapshots are also listed with `zfs list -H -o name`, which causes zrep-expire to choke. If I fix the get_all_filesystems to use `zfs list -H -t filesystem -o name` it works